### PR TITLE
reimplements read_entire_file_etc to use less system calls

### DIFF
--- a/entire_file_utils.h
+++ b/entire_file_utils.h
@@ -2,15 +2,11 @@
 #define ENTIRE_FILE_UTILS_H
 
 #include <stdio.h>
+#include <fcntl.h>
 #include <stdlib.h>
+#include <unistd.h>
+#include <string.h>
 
-#define MALLOC(num_elements, type) ((type*) malloc((num_elements) * sizeof(type)))
-#define ARRAY_LEN(arr) (sizeof(arr) / sizeof((arr)[0]))
-
-#ifdef _MSC_VER
-// Disable warnings for using fopen when compiling with MSVC
-#define _CRT_SECURE_NO_WARNINGS
-#endif
 
 // Structure representing the contents of a file in memory
 typedef struct EntireFile {
@@ -19,76 +15,45 @@ typedef struct EntireFile {
 } EntireFile;
 
 /*
-     Reads an entire file into memory.
-     Example usage:
+  Reads an entire file into memory.
+  Example usage:
 
-     EntireFile file = read_entire_file_into_memory("some/path/to/file");
-     // We can also check file.len
-     if (!file.contents) {
-         // Could not read the file. Handle error
-     }
-
-     // File was read successfully
- */
+  EntireFile file = read_entire_file_into_memory("some/path/to/file");
+  Never fails, exits on error.
+*/
 inline EntireFile read_entire_file_into_memory(const char* path) {
     EntireFile res = {0};
-        long int file_size;
-        size_t bytes_read;
-
     if (!path) {
         fprintf(stderr, "No path was given to read\n");
-        return res;
+        exit(1);
     }
 
-    FILE* file = fopen(path, "rb");
-    if (!file) {
+    int fd = open(path, O_RDONLY);
+    if (fd == -1) {
         fprintf(stderr, "Could not open %s for reading\n", path);
-        goto error;
+        exit(1);
     }
 
-    if (fseek(file, 0, SEEK_END) != 0) {
-        fprintf(stderr, "Could not seek to the end of file %s\n", path);
-        goto error;
+    while (1) {
+        char buf[BUFSIZ];
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n == -1) {
+            perror("read");
+            exit(1);
+        }
+        if (n == 0) {
+            break;
+        }
+        res.len += n;
+        res.contents = (char *)realloc(res.contents, res.len);
+        if (res.contents == NULL) {
+            perror("malloc");
+            exit(1);
+        }
+        memcpy(res.contents + res.len - n, buf, n);
     }
-
-    file_size = ftell(file);
-    if (file_size == -1L) {
-        fprintf(stderr, "Could not tell the size of file %s\n", path);
-        goto error;
-    }
-
-    if (fseek(file, 0, SEEK_SET) != 0) {
-        fprintf(stderr, "Could not set the cursor to the start of file %s\n", path);
-        goto error;
-    }
-
-    res.contents = MALLOC(file_size, char);
-    if (!res.contents) {
-        fprintf(stderr, "Could not allocate memory for storing contents of file %s\n", path);
-        goto error;
-    }
-
-    bytes_read = fread(res.contents, sizeof(char), file_size, file);
-    if (bytes_read != file_size) {
-        fprintf(stderr, "Could not read entire file %s\n", path);
-        goto error;
-    }
-    res.len = bytes_read;
-
-    fclose(file);
-
+    close(fd);
     return res;
-
-error:
-    if (file) {
-        fclose(file);
-    }
-
-    if (res.contents) {
-        free(res.contents);
-    }
-
-    return {0};
 }
 
 #endif // ENTIRE_FILE_UTILS_H

--- a/fuzzing_utils.cc
+++ b/fuzzing_utils.cc
@@ -32,10 +32,6 @@ void RunFuzzTests(const char* file_path) {
     for (const auto &testcase : files) {
         const char* testcase_ptr = testcase.string().c_str();
         EntireFile file = read_entire_file_into_memory(testcase.string().c_str());
-        if (!file.contents) {
-            std::cerr << "Failed to read file: " << testcase.string().c_str() << std::endl;
-            return;
-        }
         if (file.len < 2) {
             std::cerr << "File is too small." << std::endl;
             free(file.contents);


### PR DESCRIPTION
The original implementation uses too many system calls and buffered input, which doesn't play nice with fuzzing and especially with symbolic execution.

Warning: I didn't try to compile it on MSVC, but I hope it is portable enough. 